### PR TITLE
Add ssh_fileglob_path to allow to change the file path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 home_directory: /home/admin/
 user_uid: false
+ssh_fileglob_path: "/home/admin/{{ customer }}"
+
 ssh_config:
   - host: "*"
     StrictHostKeyChecking: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   become: true
   become_user: "{{ user }}"
   with_fileglob:
-    - "/home/admin/{{ customer }}/files/ssh/{{ user }}/*.pub"
+    - "{{ ssh_fileglob_path }}/files/ssh/{{ user }}/*.pub"
 
 - name: "Install deploy private key"
   copy: src={{ item }} dest="{{ home_directory }}/.ssh/deploy" mode=0600


### PR DESCRIPTION
By default we check in /home/admin/customer/file/...
But sometime we have to change the ansible repository name by something
else than the customer name.

Example: we are testing an ansible branch and we want to clone it in
/home/admin/customer-mybranch. If we want to use ssh key from
customer-mybranch, we need to update the ssh_fileglob_path to
/home/admin/customer-mybranch.

This commit Make it able to configure by a variable