### PR TITLE
config: remove become to drop the file with user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,10 +49,9 @@
 - name: "Configure SSH for user"
   template:
     src: "ssh_config.j2"
+    owner: "{{ user }}"
     dest: "{{ home_directory }}/.ssh/config"
     mode: 0644
-  become: true
-  become_user: "{{ user }}"
 
 - name: Make sure history size is not localy declared in .bashrc
   lineinfile:


### PR DESCRIPTION
Instead of using become, which doesn't make quite sense here, the owner
directive has been use to make it more logical/simple.

Otherwise it can produce errors like:
```    amazon-ebs: fatal: [127.0.0.1]: FAILED! => {"failed": true, "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: changing ownership of '/tmp/ansible-tmp-1521024178.82-36242383270833/': Operation not permitted
chown: changing ownership of '/tmp/ansible-tmp-1521024178.82-36242383270833/stat.py': Operation not permitted
). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}
 ```